### PR TITLE
Limit cached pyright versions

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -5,3 +5,11 @@
 ## Running the Server
 
 > node index.js
+
+## Pyright Version Cache
+
+The server caches downloaded versions of Pyright under `pyright_local`. To
+limit disk usage, only the 20 most recently used versions are retained. When
+this limit is exceeded, the least-recently-used version is removed
+automatically. Usage information is persisted so the cache survives server
+restarts.

--- a/server/README.md
+++ b/server/README.md
@@ -5,11 +5,3 @@
 ## Running the Server
 
 > node index.js
-
-## Pyright Version Cache
-
-The server caches downloaded versions of Pyright under `pyright_local`. To
-limit disk usage, only the 20 most recently used versions are retained. When
-this limit is exceeded, the least-recently-used version is removed
-automatically. Usage information is persisted so the cache survives server
-restarts.

--- a/server/src/sessionManager.ts
+++ b/server/src/sessionManager.ts
@@ -442,7 +442,6 @@ async function installPyright(requestedVersion: string | undefined): Promise<Ins
         if (fs.existsSync(dirName)) {
             logger.info(`Pyright version ${version} already installed`);
             recordPyrightVersionUse(version);
-            prunePyrightCache();
             resolve({ pyrightVersion: version, localDirectory: dirName });
             return;
         }


### PR DESCRIPTION
## Summary
- track usage of cached pyright versions with a persisted manifest
- keep only 20 most recently used pyright versions and prune older ones
- document version cache limit in server README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b38fb4c0148321a10b7109a0eea4e3